### PR TITLE
make SSL certificate verification optional

### DIFF
--- a/pyimgur/__init__.py
+++ b/pyimgur/__init__.py
@@ -640,7 +640,7 @@ class Imgur:
     but instead use the methods in this class to get them.
     """
     def __init__(self, client_id, client_secret=None, access_token=None,
-                 refresh_token=None):
+                 refresh_token=None, verify=True):
         """
         Initialize the Imgur object.
 
@@ -659,6 +659,8 @@ class Imgur:
             access_tokens expire after 1 hour, we need a way to request new
             ones without going through the entire authorization step again. It
             does not expire.
+        :param verify: Verify SSL certificate of server
+            (can result in SSLErrors)?
         """
         self.is_authenticated = False
         self.access_token = access_token
@@ -671,6 +673,7 @@ class Imgur:
         self.ratelimit_userremaining = None
         self.ratelimit_userreset = None
         self.refresh_token = refresh_token
+        self.verify = verify
 
     def _send_request(self, url, needs_auth=False, **kwargs):
         """
@@ -709,7 +712,7 @@ class Imgur:
             url.format(page)
         kwargs['authentication'] = auth
         while True:
-            result = request.send_request(url, **kwargs)
+            result = request.send_request(url, verify=self.verify, **kwargs)
             new_content, ratelimit_info = result
             if is_paginated and new_content and limit > len(new_content):
                 content += new_content

--- a/pyimgur/request.py
+++ b/pyimgur/request.py
@@ -58,7 +58,7 @@ def to_imgur_format(params):
 
 
 def send_request(url, params=None, method='GET', data_field='data',
-                 authentication=None):
+                 authentication=None, verify=True):
     # TODO figure out if there is a way to minimize this
     # TODO Add error checking
     params = to_imgur_format(params)
@@ -77,13 +77,14 @@ def send_request(url, params=None, method='GET', data_field='data',
     tries = 0
     while not is_succesful_request and tries <= MAX_RETRIES:
         if method == 'GET':
-            resp = requests.get(url, params=params, headers=headers)
+            resp = requests.get(url, params=params, headers=headers,
+                                verify=verify)
         elif method == 'POST':
-            resp = requests.post(url, params, headers=headers)
+            resp = requests.post(url, params, headers=headers, verify=verify)
         elif method == 'PUT':
-            resp = requests.put(url, params, headers=headers)
+            resp = requests.put(url, params, headers=headers, verify=verify)
         elif method == 'DELETE':
-            resp = requests.delete(url, headers=headers)
+            resp = requests.delete(url, headers=headers, verify=verify)
         if resp.status_code in RETRY_CODES or resp.content == "":
             tries += 1
         else:


### PR DESCRIPTION
This makes it possible to skip SSL certificate verification (that can fail with SSLError occasionally). The default is left at checking SSL certificate.
This can be important for automated test environments that use image uploads.
See https://travis-ci.org/obspy/obspy/jobs/29074482#L841 for an example of a failing test suite due to failed SSL check.
